### PR TITLE
Fixes racecondition

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -62,11 +62,10 @@ func (ex *Executor) doExecute() (interface{}, error) {
 		start := time.Now()
 		value, err := ex.command.Run()
 		elapsed = time.Since(start)
-		if value != nil {
-			valueChan <- value
-		}
 		if err != nil {
 			errorChan <- err
+		} else if value != nil {
+			valueChan <- value
 		}
 	}()
 


### PR DESCRIPTION
Hi,

this PR fixes a race-condition when the `Run()` method returns a non-nil value and an error. This can happen, if a backend function is just piped-through that has a non-nilable type.

Example:

```

func (client *Client) GetOpenBookings() (int, error) {
 // ..of no interest, assume error for example purpose
return -1, fmt.Errorf("Backend unavailable")
} 

// Just calls client.GetOpenBookings()
func (cmd *GetOpenBookingsCommand) Run() (interface{}, error) {
  return cmd.client.GetOpenBookings()
}
```

Since the previous behavior would now write values into both the `valueChan` and `errorChan`, the behavior might sometimes pick `-1` from the valueChan, and sometimes the error from `errorChan`.

This change interprets a non-nil error value as an error and ensures that a value is never returned.
