### PR TITLE
Move fallback into separate interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,18 @@ How to use
 ```go
 type Interface interface {
 	Run() (interface{}, error)
-	Fallback() (interface{}, error)
 	Timeout() time.Duration
 	Name() string
 	Group() string
+}
+```
+
+There is also a `goHystrix.FallbackInterface`, if you need a fallback function:
+
+```
+type FallbackInterface interface {
+	Interface
+	Fallback() (interface{}, error)
 }
 ```
 


### PR DESCRIPTION
This PR implements dahernan/goHystrix#1 by moving the `Fallback()` method into a separate interface, thus making it optional.

If a fallback is needed, and the command does not implement a fallback, an error is now returned.
