### PR TITLE
Added recover() call for panics in Run()

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -63,12 +63,17 @@ func (ex *Executor) doExecute() (interface{}, error) {
 	errorChan := make(chan error, 1)
 	var elapsed time.Duration
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				errorChan <- fmt.Errorf("Recovered from panic: %v", r)
+			}
+		}()
 		start := time.Now()
 		value, err := ex.command.Run()
 		elapsed = time.Since(start)
 		if err != nil {
 			errorChan <- err
-		} else if value != nil {
+		} else {
 			valueChan <- value
 		}
 	}()


### PR DESCRIPTION
This PR fixes two things:

1) If `Command.Run()` panics, we timed out before. Now we receive an error: `Recovered from panic: <panic-msg>`
2) If `Run()` returned `nil, nil`, we timed out. Now we receive `nil, nil` correctly.
